### PR TITLE
Add possibility to specify additional settings

### DIFF
--- a/WkWrap.Core/HtmlToPdfConverter.cs
+++ b/WkWrap.Core/HtmlToPdfConverter.cs
@@ -58,8 +58,9 @@ namespace WkWrap.Core
         /// <param name="html">HTML content.</param>
         /// <param name="htmlEncoding">HTML content encoding.</param>
         /// <param name="settings">Conversion settings.</param>
+        /// <param name="additonalSettings">Additional settings to append to the conversion settings.</param>
         /// <returns></returns>
-        public byte[] ConvertToPdf(string html, Encoding htmlEncoding, ConversionSettings settings)
+        public byte[] ConvertToPdf(string html, Encoding htmlEncoding, ConversionSettings settings, string additionalSettings = string.Empty)
         {
             if (settings == null)
                 throw new ArgumentNullException(nameof(settings));
@@ -70,7 +71,7 @@ namespace WkWrap.Core
             using (var inputStream = new MemoryStream(htmlEncoding.GetBytes(html)))
             using (var outputStream = new MemoryStream())
             {
-                ConvertToPdf(inputStream, outputStream, settings);
+                ConvertToPdf(inputStream, outputStream, settings, additionalSettings);
                 result = outputStream.ToArray();
             }
             return result;
@@ -82,10 +83,12 @@ namespace WkWrap.Core
         /// <param name="inputStream">HTML content input stream.</param>
         /// <param name="outputStream">PDF file output stream.</param>
         /// <param name="settings">Conversion settings.</param>
+        /// <param name="additonalSettings">Additional settings to append to the conversion settings.</param>
         public void ConvertToPdf(
             Stream inputStream,
             Stream outputStream,
-            ConversionSettings settings)
+            ConversionSettings settings,
+            string additionalSettings = string.Empty)
         {
             if (inputStream == null)
                 throw new ArgumentNullException(nameof(inputStream));
@@ -93,8 +96,9 @@ namespace WkWrap.Core
                 throw new ArgumentNullException(nameof(outputStream));
             if (settings == null)
                 throw new ArgumentNullException(nameof(settings));
-
-            ConvertToPdfInternal(inputStream, outputStream, settings.ToString().Trim(), settings.ExecutionTimeout);
+                
+            var combinedSettings = $"{settings.ToString().Trim()} {additionalSettings}".Trim();
+            ConvertToPdfInternal(inputStream, combinedSettings, finalSettings, settings.ExecutionTimeout);
         }
 
         /// <summary>

--- a/WkWrap.Core/HtmlToPdfConverter.cs
+++ b/WkWrap.Core/HtmlToPdfConverter.cs
@@ -60,7 +60,7 @@ namespace WkWrap.Core
         /// <param name="settings">Conversion settings.</param>
         /// <param name="additonalSettings">Additional settings to append to the conversion settings.</param>
         /// <returns></returns>
-        public byte[] ConvertToPdf(string html, Encoding htmlEncoding, ConversionSettings settings, string additionalSettings = string.Empty)
+        public byte[] ConvertToPdf(string html, Encoding htmlEncoding, ConversionSettings settings, string additionalSettings = "")
         {
             if (settings == null)
                 throw new ArgumentNullException(nameof(settings));
@@ -88,7 +88,7 @@ namespace WkWrap.Core
             Stream inputStream,
             Stream outputStream,
             ConversionSettings settings,
-            string additionalSettings = string.Empty)
+            string additionalSettings = "")
         {
             if (inputStream == null)
                 throw new ArgumentNullException(nameof(inputStream));
@@ -98,7 +98,7 @@ namespace WkWrap.Core
                 throw new ArgumentNullException(nameof(settings));
                 
             var combinedSettings = $"{settings.ToString().Trim()} {additionalSettings}".Trim();
-            ConvertToPdfInternal(inputStream, combinedSettings, finalSettings, settings.ExecutionTimeout);
+            ConvertToPdfInternal(inputStream, outputStream, combinedSettings, settings.ExecutionTimeout);
         }
 
         /// <summary>

--- a/WkWrap.Core/IHtmlToPdfConverter.cs
+++ b/WkWrap.Core/IHtmlToPdfConverter.cs
@@ -31,8 +31,9 @@ namespace WkWrap.Core
         /// <param name="html">HTML content.</param>
         /// <param name="htmlEncoding">HTML content encoding.</param>
         /// <param name="settings">Conversion settings.</param>
+        /// <param name="additonalSettings">Additional settings to append to the conversion settings.</param>
         /// <returns></returns>
-        byte[] ConvertToPdf(string html, Encoding htmlEncoding, ConversionSettings settings);
+        byte[] ConvertToPdf(string html, Encoding htmlEncoding, ConversionSettings settings, string additionalSettings);
 
         /// <summary>
         /// Generate PDF into specified output <see cref="Stream" />.
@@ -40,7 +41,8 @@ namespace WkWrap.Core
         /// <param name="inputStream">HTML content input stream.</param>
         /// <param name="outputStream">PDF file output stream.</param>
         /// <param name="settings">Conversion settings.</param>
-        void ConvertToPdf(Stream inputStream, Stream outputStream, ConversionSettings settings);
+        /// <param name="additonalSettings">Additional settings to append to the conversion settings.</param>
+        void ConvertToPdf(Stream inputStream, Stream outputStream, ConversionSettings settings, string additionalSettings);
 
         /// <summary>
         /// Generate PDF into specified output <see cref="Stream" />.


### PR DESCRIPTION
Lets the user specify additional settings to pass to WkHtmlToPdf for the conversion instead of only having the option to set all options directly via the string parameter or only having the settings available in the ConversionSettings class.

This code needs testing, I modified it quickly in the browser and I might have missed something important. 

The important point is you get the idea, I would just like to have an option to combine both settings made available through ConversionSettings AND the ones I would specify in addition when calling the converter. 